### PR TITLE
feat: postcss-parent-selector to prevent tailwind clashes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,13 +40,14 @@
         "@types/uuid": "^9.0.8",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
-        "autoprefixer": "^10.4.19",
+        "autoprefixer": "^10.4.20",
         "eslint": "^8.56.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.5",
-        "postcss": "^8.4.38",
+        "postcss": "^8.4.41",
+        "postcss-parent-selector": "^1.0.0",
         "supabase": "^1.187.10",
-        "tailwindcss": "^3.4.3",
+        "tailwindcss": "^3.4.7",
         "typescript": "^5.2.2",
         "vite": "^5.2.8"
       }
@@ -2534,9 +2535,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.19",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz",
-      "integrity": "sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==",
+      "version": "10.4.20",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
+      "integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
       "dev": true,
       "funding": [
         {
@@ -2553,11 +2554,11 @@
         }
       ],
       "dependencies": {
-        "browserslist": "^4.23.0",
-        "caniuse-lite": "^1.0.30001599",
+        "browserslist": "^4.23.3",
+        "caniuse-lite": "^1.0.30001646",
         "fraction.js": "^4.3.7",
         "normalize-range": "^0.1.2",
-        "picocolors": "^1.0.0",
+        "picocolors": "^1.0.1",
         "postcss-value-parser": "^4.2.0"
       },
       "bin": {
@@ -2624,9 +2625,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
+      "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
       "funding": [
         {
           "type": "opencollective",
@@ -2642,10 +2643,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001587",
-        "electron-to-chromium": "^1.4.668",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.13"
+        "caniuse-lite": "^1.0.30001646",
+        "electron-to-chromium": "^1.5.4",
+        "node-releases": "^2.0.18",
+        "update-browserslist-db": "^1.1.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2672,9 +2673,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001605",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001605.tgz",
-      "integrity": "sha512-nXwGlFWo34uliI9z3n6Qc0wZaf7zaZWA1CPZ169La5mV3I/gem7bst0vr5XQH5TJXZIMfDeZyOrZnSlVzKxxHQ==",
+      "version": "1.0.30001649",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001649.tgz",
+      "integrity": "sha512-fJegqZZ0ZX8HOWr6rcafGr72+xcgJKI9oWfDW5DrD7ExUtgZC7a7R7ZYmZqplh7XDocFdGeIFn7roAxhOeYrPQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -3104,9 +3105,9 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.669",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.669.tgz",
-      "integrity": "sha512-E2SmpffFPrZhBSgf8ibqanRS2mpuk3FIRDzLDwt7WFpfgJMKDHJs0hmacyP0PS1cWsq0dVkwIIzlscNaterkPg=="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.5.tgz",
+      "integrity": "sha512-QR7/A7ZkMS8tZuoftC/jfqNkZLQO779SSW3YuZHP4eXpj3EffGLFcB/Xu9AAZQzLccTiCV+EmUo3ha4mQ9wnlA=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -3710,6 +3711,27 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-ansi/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3915,6 +3937,12 @@
       "bin": {
         "jiti": "bin/jiti.js"
       }
+    },
+    "node_modules/js-base64": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
+      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
+      "dev": true
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -4301,9 +4329,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -4522,9 +4550,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -4554,9 +4582,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.38",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
-      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+      "version": "8.4.41",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.41.tgz",
+      "integrity": "sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -4573,7 +4601,7 @@
       ],
       "dependencies": {
         "nanoid": "^3.3.7",
-        "picocolors": "^1.0.0",
+        "picocolors": "^1.0.1",
         "source-map-js": "^1.2.0"
       },
       "engines": {
@@ -4675,6 +4703,115 @@
       },
       "peerDependencies": {
         "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-parent-selector": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-parent-selector/-/postcss-parent-selector-1.0.0.tgz",
+      "integrity": "sha512-otXGcFhUNUbNbr7GneKvFM+sPgmAJ0qDUDJdDq3u9uGwri8RG5kZKR6WPAuAMv3KnmkARGxqy4axGlVvsVVgxA==",
+      "dev": true,
+      "dependencies": {
+        "postcss": "^5.2.5"
+      }
+    },
+    "node_modules/postcss-parent-selector/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postcss-parent-selector/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postcss-parent-selector/node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postcss-parent-selector/node_modules/chalk/node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/postcss-parent-selector/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/postcss-parent-selector/node_modules/has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha512-DyYHfIYwAJmjAjSSPKANxI8bFY9YtFrgkAfinBojQ8YJTOuOuav64tMUJv584SES4xl74PmuaevIyaLESHdTAA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postcss-parent-selector/node_modules/postcss": {
+      "version": "5.2.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+      "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^1.1.3",
+        "js-base64": "^2.1.9",
+        "source-map": "^0.5.6",
+        "supports-color": "^3.2.3"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/postcss-parent-selector/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postcss-parent-selector/node_modules/supports-color": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+      "integrity": "sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/postcss-selector-parser": {
@@ -5053,6 +5190,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
@@ -5269,9 +5415,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.3.tgz",
-      "integrity": "sha512-U7sxQk/n397Bmx4JHbJx/iSOOv5G+II3f1kpLpY2QeUv5DcPdcTsYLlusZfq1NthHS1c1cZoyFmmkex1rzke0A==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.7.tgz",
+      "integrity": "sha512-rxWZbe87YJb4OcSopb7up2Ba4U82BoiSGUdoDr3Ydrg9ckxFS/YWsvhN323GMcddgU65QRy7JndC7ahhInhvlQ==",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -5470,9 +5616,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -5488,8 +5634,8 @@
         }
       ],
       "dependencies": {
-        "escalade": "^3.1.1",
-        "picocolors": "^1.0.0"
+        "escalade": "^3.1.2",
+        "picocolors": "^1.0.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"

--- a/package.json
+++ b/package.json
@@ -42,13 +42,14 @@
     "@types/uuid": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
-    "autoprefixer": "^10.4.19",
+    "autoprefixer": "^10.4.20",
     "eslint": "^8.56.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "postcss": "^8.4.38",
+    "postcss": "^8.4.41",
+    "postcss-parent-selector": "^1.0.0",
     "supabase": "^1.187.10",
-    "tailwindcss": "^3.4.3",
+    "tailwindcss": "^3.4.7",
     "typescript": "^5.2.2",
     "vite": "^5.2.8"
   }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -2,5 +2,8 @@ export default {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},
+    'postcss-parent-selector': {
+      selector: '.linklib-ext'
+    },
   },
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -3,7 +3,8 @@ export default {
     tailwindcss: {},
     autoprefixer: {},
     'postcss-parent-selector': {
-      selector: '.linklib-ext'
+      selector: '.linklib-ext',
+      exclude: '.linklib-ext'
     },
   },
 }

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,31 +1,33 @@
-import * as React from "react"
-import * as PopoverPrimitive from "@radix-ui/react-popover"
+import * as React from 'react';
+import * as PopoverPrimitive from '@radix-ui/react-popover';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-const Popover = PopoverPrimitive.Root
+const Popover = PopoverPrimitive.Root;
 
-const PopoverTrigger = PopoverPrimitive.Trigger
+const PopoverTrigger = PopoverPrimitive.Trigger;
 
-const PopoverAnchor = PopoverPrimitive.Anchor
+const PopoverAnchor = PopoverPrimitive.Anchor;
 
 const PopoverContent = React.forwardRef<
-  React.ElementRef<typeof PopoverPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
-  <PopoverPrimitive.Portal>
-    <PopoverPrimitive.Content
-      ref={ref}
-      align={align}
-      sideOffset={sideOffset}
-      className={cn(
-        "linklib-ext z-50 w-72 rounded-md border border-input bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-        className
-      )}
-      {...props}
-    />
-  </PopoverPrimitive.Portal>
-))
-PopoverContent.displayName = PopoverPrimitive.Content.displayName
+	React.ElementRef<typeof PopoverPrimitive.Content>,
+	React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
+	<PopoverPrimitive.Portal>
+		<div className='linklib-ext'>
+			<PopoverPrimitive.Content
+				ref={ref}
+				align={align}
+				sideOffset={sideOffset}
+				className={cn(
+					' z-50 w-72 rounded-md border border-input bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+					className
+				)}
+				{...props}
+			/>
+		</div>
+	</PopoverPrimitive.Portal>
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
-export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };

--- a/src/index.css
+++ b/src/index.css
@@ -4,7 +4,7 @@
 @tailwind screens;
 
 @layer base {
-	html {
+	.linklib-ext {
 		--background: 225 7% 19%;
 		--foreground: 210 40% 98%;
 

--- a/src/index.css
+++ b/src/index.css
@@ -4,7 +4,7 @@
 @tailwind screens;
 
 @layer base {
-	.linklib-ext {
+	html {
 		--background: 225 7% 19%;
 		--foreground: 210 40% 98%;
 
@@ -43,7 +43,7 @@
 		--rem: 16px;
 	}
 
-	.linklib-ext .dark {
+	.dark {
 		--background: 45 46 52;
 		--foreground: 210 40% 98%;
 
@@ -80,8 +80,7 @@
 		--success-foreground: 0 0% 100%;
 	}
 
-	.linklib-ext,
-	.linklib-ext * {
+	* {
 		box-sizing: border-box; /* 1 */
 		border-width: 0; /* 2 */
 		border-style: solid; /* 2 */
@@ -90,17 +89,16 @@
 		font-size: var(--rem) !important;
 	}
 
-	.linklib-ext ::before,
-	.linklib-ext ::after {
+	::before,
+	::after {
 		--tw-content: '';
 	}
 
-	.linklib-ext :root {
+	:root {
 		font-size: var(--rem) !important;
 	}
 
-	.linklib-ext html,
-	.linklib-ext {
+	html {
 		line-height: 1.5; /* 1 */
 		-webkit-text-size-adjust: 100%; /* 2 */
 		-moz-tab-size: 4; /* 3 */
@@ -113,45 +111,45 @@
 		font-size: 16px !important;
 	}
 
-	.linklib-ext body {
+	body {
 		margin: 0; /* 1 */
 		line-height: inherit; /* 2 */
 	}
 
-	.linklib-ext hr {
+	hr {
 		height: 0; /* 1 */
 		color: inherit; /* 2 */
 		border-top-width: 1px; /* 3 */
 	}
 
-	.linklib-ext abbr[title] {
+	abbr[title] {
 		text-decoration: underline dotted;
 	}
 
-	.linklib-ext h1,
-	.linklib-ext h2,
-	.linklib-ext h3,
-	.linklib-ext h4,
-	.linklib-ext h5,
-	.linklib-ext h6 {
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6 {
 		font-size: inherit;
 		font-weight: inherit;
 	}
 
-	.linklib-ext a {
+	a {
 		color: inherit;
 		text-decoration: inherit;
 	}
 
-	.linklib-ext b,
-	.linklib-ext strong {
+	b,
+	strong {
 		font-weight: bolder;
 	}
 
-	.linklib-ext code,
-	.linklib-ext kbd,
-	.linklib-ext samp,
-	.linklib-ext pre {
+	code,
+	kbd,
+	samp,
+	pre {
 		font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
 			'Liberation Mono', 'Courier New', monospace; /* 1 */
 		font-feature-settings: normal; /* 2 */
@@ -159,37 +157,37 @@
 		font-size: 1em; /* 4 */
 	}
 
-	.linklib-ext small {
+	small {
 		font-size: 80%;
 	}
 
-	.linklib-ext sub,
-	.linklib-ext sup {
+	sub,
+	sup {
 		font-size: 75%;
 		line-height: 0;
 		position: relative;
 		vertical-align: baseline;
 	}
 
-	.linklib-ext sub {
+	sub {
 		bottom: -0.25em;
 	}
 
-	.linklib-ext sup {
+	sup {
 		top: -0.5em;
 	}
 
-	.linklib-ext table {
+	table {
 		text-indent: 0; /* 1 */
 		border-color: inherit; /* 2 */
 		border-collapse: collapse; /* 3 */
 	}
 
-	.linklib-ext button,
-	.linklib-ext input,
-	.linklib-ext optgroup,
-	.linklib-ext select,
-	.linklib-ext textarea {
+	button,
+	input,
+	optgroup,
+	select,
+	textarea {
 		font-family: inherit; /* 1 */
 		font-feature-settings: inherit; /* 1 */
 		font-variation-settings: inherit; /* 1 */
@@ -202,116 +200,127 @@
 		padding: 0; /* 3 */
 	}
 
-	.linklib-ext button,
-	.linklib-ext select {
+	button,
+	select {
 		text-transform: none;
 	}
 
-	.linklib-ext button,
-	.linklib-ext [type='button'],
-	.linklib-ext [type='reset'],
-	.linklib-ext [type='submit'] {
+	button,
+	[type='button'],
+	[type='reset'],
+	[type='submit'] {
 		-webkit-appearance: button; /* 1 */
 		background-color: transparent; /* 2 */
 		background-image: none; /* 3 */
 	}
 
-	.linklib-ext :-moz-focusring {
+	:-moz-focusring {
 		outline: auto;
 	}
 
-	.linklib-ext :-moz-ui-invalid {
+	:-moz-ui-invalid {
 		box-shadow: none;
 	}
 
-	.linklib-ext progress {
+	progress {
 		vertical-align: baseline;
 	}
 
-	.linklib-ext ::-webkit-inner-spin-button,
-	.linklib-ext ::-webkit-outer-spin-button {
+	::-webkit-inner-spin-button,
+	::-webkit-outer-spin-button {
 		height: auto;
 	}
 
-	.linklib-ext [type='search'] {
+	[type='search'] {
 		-webkit-appearance: textfield; /* 1 */
 		outline-offset: -2px; /* 2 */
 	}
 
-	.linklib-ext ::-webkit-search-decoration {
+	::-webkit-search-decoration {
 		-webkit-appearance: none;
 	}
 
-	.linklib-ext ::-webkit-file-upload-button {
+	::-webkit-file-upload-button {
 		-webkit-appearance: button; /* 1 */
 		font: inherit; /* 2 */
 	}
 
-	.linklib-ext summary {
+	summary {
 		display: list-item;
 	}
 
-	.linklib-ext p,
-	.linklib-ext pre {
+	p,
+	pre {
 		margin: 0;
 	}
 
-	.linklib-ext fieldset {
+	fieldset {
 		margin: 0;
 		padding: 0;
 	}
 
-	.linklib-ext legend {
+	legend {
 		padding: 0;
 	}
 
-	.linklib-ext ol,
-	.linklib-ext ul,
-	.linklib-ext menu {
+	ol,
+	ul,
+	menu {
 		list-style: none;
 		margin: 0;
 		padding: 0;
 	}
 
-	.linklib-ext textarea {
+	textarea {
 		resize: vertical;
 	}
 
-	.linklib-ext input::placeholder,
-	.linklib-ext textarea::placeholder {
+	input::placeholder,
+	textarea::placeholder {
 		opacity: 1; /* 1 */
 		color: #9ca3af; /* 2 */
 	}
 
-	.linklib-ext button,
-	.linklib-ext [role='button'] {
+	button,
+	[role='button'] {
 		cursor: pointer;
 	}
 
-	.linklib-ext :disabled,
-	.linklib-ext [aria-disabled='true'] {
+	:disabled,
+	[aria-disabled='true'] {
 		cursor: default;
 	}
 
-	.linklib-ext img,
-	.linklib-ext svg,
-	.linklib-ext video,
-	.linklib-ext canvas,
-	.linklib-ext audio,
-	.linklib-ext iframe,
-	.linklib-ext embed,
-	.linklib-ext object {
+	img,
+	svg,
+	video,
+	canvas,
+	audio,
+	iframe,
+	embed,
+	object {
 		display: block;
 		vertical-align: middle;
 	}
 
-	.linklib-ext img,
-	.linklib-ext video {
+	img,
+	video {
 		max-width: 100%;
 		height: auto;
 	}
 
-	.linklib-ext [hidden] {
+	[hidden] {
 		display: none;
 	}
 }
+
+/* -sidebar {
+	font-size: 16px;
+	line-height: 1.5;
+	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+		'Helvetica Neue', Arial, sans-serif;
+}
+
+-sidebar * {
+	box-sizing: border-box;
+} */

--- a/src/index.css
+++ b/src/index.css
@@ -312,6 +312,12 @@
 	[hidden] {
 		display: none;
 	}
+
+	/* Add this near the end of your file, after your Tailwind imports */
+	[type='button'] {
+		-webkit-appearance: none;
+		appearance: none;
+	}
 }
 
 /* -sidebar {

--- a/src/scripts/highlighter/components/Highlight.tsx
+++ b/src/scripts/highlighter/components/Highlight.tsx
@@ -85,6 +85,7 @@ export const Highlight = ({
 
 				const containers = ranges.map((range) => {
 					const container = document.createElement('span');
+					container.className = 'linklib-ext';
 					const content = range.extractContents();
 					range.startContainer.parentNode?.normalize();
 					range.insertNode(container);

--- a/src/scripts/main.tsx
+++ b/src/scripts/main.tsx
@@ -22,10 +22,7 @@ const reactRoot = ReactDOM.createRoot(root);
 
 reactRoot.render(
 	<React.StrictMode>
-		{/* <style type='text/css'>{styles}</style> */}
-		{/* <style type='text/css'>{styles2}</style> */}
-		{/* <script src='https://cdn.tailwindcss.com'></script> */}
-		<div className='linklib-ext'>
+		<div className='linklib-ext .linklib-ext'>
 			<html>
 				<HighlighterApp />
 				<ImageDrop />

--- a/src/scripts/main.tsx
+++ b/src/scripts/main.tsx
@@ -24,7 +24,7 @@ reactRoot.render(
 	<React.StrictMode>
 		{/* <style type='text/css'>{styles}</style> */}
 		{/* <style type='text/css'>{styles2}</style> */}
-		<script src='https://cdn.tailwindcss.com'></script>
+		{/* <script src='https://cdn.tailwindcss.com'></script> */}
 		<div className='linklib-ext'>
 			<html>
 				<HighlighterApp />

--- a/src/scripts/sidebar/HighlightSidebar.tsx
+++ b/src/scripts/sidebar/HighlightSidebar.tsx
@@ -2,21 +2,25 @@ import React from 'react';
 import { HighlightData } from '@/scripts/highlighter/types/HighlightData';
 
 interface SidebarProps {
-  highlights: { [key: string]: HighlightData };
+	highlights: { [key: string]: HighlightData };
 }
 
 const Sidebar: React.FC<SidebarProps> = ({ highlights }) => {
-  return (
-    <div className="linklib-ext-sidebar fixed right-0 top-0 h-full w-64 bg-white shadow-lg overflow-y-auto z-50">
-      <h2 className="text-lg font-bold p-4">Highlights</h2>
-      {Object.entries(highlights).map(([uuid, highlight]) => (
-        <div key={uuid} className="p-4 border-b">
-          <p className="text-sm font-medium">{highlight.matching.body.substring(0, 50)}...</p>
-          {highlight.note && <p className="text-xs mt-2 italic">{highlight.note}</p>}
-        </div>
-      ))}
-    </div>
-  );
+	return (
+		<div className='linklib-ext-sidebar fixed right-0 top-0 h-full w-64 shadow-lg overflow-y-auto z-50'>
+			<h2 className='text-lg font-bold p-4'>Highlights</h2>
+			{Object.entries(highlights).map(([uuid, highlight]) => (
+				<div key={uuid} className='p-4 border-b'>
+					<p className='text-sm font-medium'>
+						{highlight.matching.body.substring(0, 50)}...
+					</p>
+					{highlight.note && (
+						<p className='text-xs mt-2 italic'>{highlight.note}</p>
+					)}
+				</div>
+			))}
+		</div>
+	);
 };
 
 export default Sidebar;

--- a/src/scripts/sidebar/HighlightSidebar.tsx
+++ b/src/scripts/sidebar/HighlightSidebar.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { HighlightData } from '@/scripts/highlighter/types/HighlightData';
+
+interface SidebarProps {
+  highlights: { [key: string]: HighlightData };
+}
+
+const Sidebar: React.FC<SidebarProps> = ({ highlights }) => {
+  return (
+    <div className="linklib-ext-sidebar fixed right-0 top-0 h-full w-64 bg-white shadow-lg overflow-y-auto z-50">
+      <h2 className="text-lg font-bold p-4">Highlights</h2>
+      {Object.entries(highlights).map(([uuid, highlight]) => (
+        <div key={uuid} className="p-4 border-b">
+          <p className="text-sm font-medium">{highlight.matching.body.substring(0, 50)}...</p>
+          {highlight.note && <p className="text-xs mt-2 italic">{highlight.note}</p>}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default Sidebar;


### PR DESCRIPTION
added parent selector so that our tailwind classes all compile to require a parent of linklib-ext, preventing from any overlap (unless some website puts linklib-ext in their classname for no reason?)