### PR TITLE
Making chrome extension id stable

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,7 @@
   "name": "Linklib",
   "description": "Extension for Linklib",
   "version": "1.0",
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArjvcTUONM6Lo6RisOAk+hY75jv1eD5+runjkwknhiKpaR2gPc8OELRPg3mKPtLTaP10v9ns4O5zQwgHztVTwgKYrWRZZPUKcWjLXTmwlCsVwcotpTV+u+n89Kb6qbFvGGYlf6IakP5IjldcThZkLj3WMzNqmFz9U+pyguMlCStYpYipXLzgwzRCgUc/fzMqYGXfQEGXbERgU37OmfssPtAm2+600hFIyhLsFTGm+Jz7OOkbSLD+BXXQ5YfW5ysY91NYPQCuU5iDgYGpbG7GJ8XhQt1SayZ02vLFBB+ukLZ+fm+NAc2BTnUWMhnY94og9XYmrGUg9zN7A5n7Fzf4e1wIDAQAB",
   "action": {
     "default_popup": "index.html",
     "default_icon": "icon48.png"


### PR DESCRIPTION
With google auth, the redirect URI is formed using the chrome extension's ID. These ID's are unstable unless the public key is explicitly specified in the manifest.json so that the redirect URI it attempts is always the same.