### PR TITLE
fix: emojis can be clicked on without a note

### DIFF
--- a/src/scripts/highlighter/components/NotesModal.tsx
+++ b/src/scripts/highlighter/components/NotesModal.tsx
@@ -65,10 +65,12 @@ export const NotesModal = ({
 
 	useEffect(() => {
 		const handleClickOutside = (event: MouseEvent) => {
+			const emojiPicker = document.querySelector('.emoji-picker');
 			if (
 				modalRef.current &&
 				!modalRef.current.contains(event.target as Node) &&
-				!manuallyClosed // Only close on click outside if not manually closed
+				!manuallyClosed && // Only close on click outside if not manually closed
+				(!emojiPicker || !emojiPicker.contains(event.target as Node))
 			) {
 				onClose();
 			}

--- a/src/scripts/highlighter/components/NotesModal.tsx
+++ b/src/scripts/highlighter/components/NotesModal.tsx
@@ -82,6 +82,13 @@ export const NotesModal = ({
 		};
 	}, [onClose, manuallyClosed]);
 
+	// Add this effect after your other useEffect hooks
+	useEffect(() => {
+		if (isPopoverOpen && inputRef.current) {
+			inputRef.current.focus();
+		}
+	}, [isPopoverOpen]);
+
 	// If manually closed and has notes, show the circular button
 	if (manuallyClosed && notes.length > 0) {
 		return (

--- a/src/scripts/highlighter/components/Reactions/EmojiPicker.tsx
+++ b/src/scripts/highlighter/components/Reactions/EmojiPicker.tsx
@@ -24,14 +24,15 @@ export const EmojiPicker = ({
 		<Popover>
 			<PopoverTrigger>{trigger}</PopoverTrigger>
 			<PopoverContent
-				className='mt-2 p-0 border-none shadow-lg w-fit h-fit'
+				className='mt-2 p-0 border-none shadow-lg w-fit h-fit emoji-picker z-infinite+1'
 				side={side}
 				align={align}
 				sideOffset={5}
 			>
 				<Picker
 					data={data}
-					onEmojiSelect={(emoji: any) => {
+					onEmojiSelect={(emoji: any, e: MouseEvent) => {
+						e.stopPropagation(); // Add this line
 						onEmojiSelect(emoji.native);
 					}}
 					theme='dark'


### PR DESCRIPTION
- emoji popovers now visually supercede notesModals
- emoji popovers can be clicked on without the noteModal dissapearing 
- when a noteModal is opened or clicked on, it now focuses the text input so the user can type right away