### PR TITLE
feat: QoL fixes 2

### DIFF
--- a/src/scripts/highlighter/HighlighterApp.tsx
+++ b/src/scripts/highlighter/HighlighterApp.tsx
@@ -165,11 +165,11 @@ const HighlighterApp: React.FC = () => {
 						);
 
 						// Save the merged highlight to the backend
-						await saveHighlight(mergedHighlight);
 						// Perform additional actions if provided
 						if (additionalActions) {
 							additionalActions(mergedHighlight);
 						}
+						await saveHighlight(mergedHighlight);
 						toast({
 							title: 'Successfully updated and merged highlight.',
 						});
@@ -195,7 +195,6 @@ const HighlighterApp: React.FC = () => {
 						userSelection.empty();
 					}
 				} else {
-					// No overlap detected; proceed as usual
 					setHighlights((prevHighlights) => ({
 						...prevHighlights,
 						[highlightData.uuid]: highlightData,
@@ -203,7 +202,6 @@ const HighlighterApp: React.FC = () => {
 
 					try {
 						await saveHighlight(highlightData);
-						// Perform additional actions if provided
 						if (additionalActions) {
 							additionalActions(highlightData);
 						}
@@ -439,8 +437,7 @@ const HighlighterApp: React.FC = () => {
 					onDelete={() => handleDeleteHighlight(uuid)}
 					notesOpen={openNoteUuid === uuid}
 					highlightColor={getHighlightColour(
-						highlightData.user_meta.name ||
-							highlightData.user_meta.firstName
+						highlightData.user_meta.name
 					)}
 				/>
 			))}

--- a/src/scripts/highlighter/components/Comment/Comment.tsx
+++ b/src/scripts/highlighter/components/Comment/Comment.tsx
@@ -26,6 +26,13 @@ const Comment: React.FC<CommentProps> = ({
 	const [editValue, setEditValue] = useState(note.value);
 	const [isHovering, setIsHovering] = useState(false);
 
+	const handleSaveEdit = () => {
+		if (editValue.trim() !== note.value) {
+			onEdit(note, editValue);
+		}
+		setIsEditing(false);
+	};
+
 	return (
 		<div
 			className='p-3 text-white text-sm'
@@ -72,6 +79,12 @@ const Comment: React.FC<CommentProps> = ({
 						value={editValue}
 						onChange={(e) => setEditValue(e.target.value)}
 						className='min-h-[100px] resize-none'
+						onKeyDown={(e) => {
+							if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+								e.preventDefault();
+								handleSaveEdit();
+							}
+						}}
 					/>
 					<div className='flex gap-1 justify-end'>
 						<button
@@ -82,7 +95,7 @@ const Comment: React.FC<CommentProps> = ({
 						</button>
 						<button
 							className='hover:text-white  hover:border-white flex justify-center align-center items-center border border-transparent cursor-pointer w-6 h-6 rounded-lg p-1 transition-colors duration-150'
-							onClick={() => onEdit(note, editValue)}
+							onClick={handleSaveEdit}
 						>
 							<Check className='h-4 w-4' />
 						</button>

--- a/src/scripts/highlighter/components/NotesModal.tsx
+++ b/src/scripts/highlighter/components/NotesModal.tsx
@@ -85,6 +85,19 @@ export const NotesModal = ({
 		setIsPopoverOpen(true);
 	}, authContext);
 
+	useEffect(() => {
+		if (isPopoverOpen && inputRef.current) {
+			const timeoutId = setTimeout(() => {
+				inputRef.current?.focus();
+				// Position cursor at end of text
+				const length = inputRef.current.value.length;
+				inputRef.current.setSelectionRange(length, length);
+			}, 500);
+
+			return () => clearTimeout(timeoutId);
+		}
+	}, [isPopoverOpen]);
+
 	if (!isPopoverOpen && notes.length > 0) {
 		return (
 			<ThreadContainer ref={modalRef}>

--- a/src/scripts/highlighter/components/NotesModal.tsx
+++ b/src/scripts/highlighter/components/NotesModal.tsx
@@ -66,6 +66,13 @@ export const NotesModal = ({
 	useEffect(() => {
 		const handleClickOutside = (event: MouseEvent) => {
 			const emojiPicker = document.querySelector('.emoji-picker');
+			const dialog = document.querySelector('[role="dialog"]');
+
+			// Don't close if delete dialog is open
+			if (showDeleteDialog || dialog?.contains(event.target as Node)) {
+				return;
+			}
+
 			if (
 				modalRef.current &&
 				!modalRef.current.contains(event.target as Node) &&
@@ -79,7 +86,7 @@ export const NotesModal = ({
 		return () => {
 			document.removeEventListener('mousedown', handleClickOutside);
 		};
-	}, [onClose]);
+	}, [onClose, showDeleteDialog]);
 
 	const handlePopoverOpen = withAuth(() => {
 		setIsPopoverOpen(true);


### PR DESCRIPTION
- [ ] autofocus now works 
- [ ] cmd + enter to save editing comments
- [ ] when the user clicks delete on a comment with notes, the delete dialogue can be clicked on to delete (previously the popover would be set to false and it would no longer render the dialogue)